### PR TITLE
Compose all layer transformations when initializing widget controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu12
 Either install via pip:
 
 ```bash
-pip install napari-nninteractive`
+pip install napari-nninteractive
 ```
 
 Or clone and install this repository:

--- a/src/napari_nninteractive/widget_controls.py
+++ b/src/napari_nninteractive/widget_controls.py
@@ -249,6 +249,9 @@ class LayerControls(BaseGUI):
         _shape = image_layer.data.shape
         _affine = image_layer.affine
         _spacing = image_layer.scale
+        _origin = image_layer.translate
+        _direction = image_layer.rotate
+        _shear = image_layer.shear
 
         # 1. Check and Correct Non-orthogonal Data
         with warnings.catch_warnings():
@@ -276,7 +279,7 @@ class LayerControls(BaseGUI):
             _direction[-2:, -2:] = _affine.rotate
             _shear = np.insert(_affine.shear, 0, 0)
 
-            _affine = Affine(scale=_spacing, translate=_origin, rotate=_direction, shear=_shear)
+        _affine = Affine(scale=_spacing, translate=_origin, rotate=_direction, shear=_shear)
 
         self.session_cfg = {
             "name": image_name,


### PR DESCRIPTION
Adresses https://github.com/MIC-DKFZ/napari-nninteractive/issues/3

In order to include scale and other layer transforms in the `Affine`-object stored in `session_cfg` the behavior that is used for 2D images is replicated, and the additional transforms are included also for 3D images. 

With this applied, the tools work as expected with the snippet from the issue above.