### PR TITLE
Use AdjustToMinimumContentsLengthWithIcon which works on qt5 and qt6

### DIFF
--- a/src/napari_nninteractive/widget_gui.py
+++ b/src/napari_nninteractive/widget_gui.py
@@ -123,7 +123,7 @@ class BaseGUI(QWidget):
         self.model_selection = setup_combobox(
             _layout, options=model_options, function=self.on_model_selected
         )
-        self.model_selection.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+        self.model_selection.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
 
         _boxlayout = QHBoxLayout()
         _layout.addLayout(_boxlayout)
@@ -150,7 +150,7 @@ class BaseGUI(QWidget):
         self.image_selection = setup_layerselect(
             _layout, viewer=self._viewer, layer_type=Image, function=self.on_image_selected
         )
-        self.image_selection.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+        self.image_selection.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
 
         _group_box.setLayout(_layout)
         return _group_box


### PR DESCRIPTION
Depends on https://github.com/MIC-DKFZ/napari_toolkit/pull/2
Closes: https://github.com/MIC-DKFZ/napari-nninteractive/issues/7

As noted here: https://github.com/MIC-DKFZ/napari-nninteractive/issues/7#issuecomment-2741753488
Qt6 doesn't have `AdjustToMinimumContentsLength` just `AdjustToMinimumContentsLengthWithIcon`
See: https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QComboBox.html#PySide6.QtWidgets.QComboBox.SizeAdjustPolicy
Qt5 has both.
So this PR uses `AdjustToMinimumContentsLengthWithIcon` for compatibility.
Tested locally with pyqt5 and pyqt6, I see no differences in the layout, which is consistent with the docs I linked above.

