### PR TITLE
bump opacity of labels layers to 0.6

### DIFF
--- a/src/napari_nninteractive/widget_controls.py
+++ b/src/napari_nninteractive/widget_controls.py
@@ -157,7 +157,7 @@ class LayerControls(BaseGUI):
             data,
             # self._data_result,
             name=name,
-            opacity=0.3,
+            opacity=0.6,
             affine=self.session_cfg["affine"],
             scale=self.session_cfg["scale"],
             translate=self.session_cfg["translate"],


### PR DESCRIPTION
I mentioned this here:
https://github.com/MIC-DKFZ/napari-nninteractive/issues/8#issuecomment-2725089328

For the images I tested and even the Cells 3D example, the 0.3 opacity was too low for me to really see that the segmentation worked!
In this PR I bump it to 0.6 which to me looks pretty good with the new aggregation too.
(tested locally)