### PR TITLE
ENH: Add [all] optional dependency and use it in the README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ For Ubuntu with a Nvidia GPU, pick 'stable', 'Linux', 'Pip', 'Python', 'CUDA12.6
 pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu126
 ```
 
-##### 3. Install this repository + dependencies via
+##### 3. Install this package, including napari & dependencies, via
 
 Either install via pip:
 
 ```bash
-pip install napari-nninteractive
+pip install "napari-nninteractive[all]"  # the [all] here is napari[all]
 ```
 
 Or clone and install this repository:
@@ -79,6 +79,7 @@ git clone https://github.com/MIC-DKFZ/napari-nninteractive
 cd napari-nninteractive
 pip install -e .
 ```
+Note: in this case you will need to have installed a Qt backend for napari, e.g. pyqt5 or pyqt6.
 
 **Note:** Model weights are automatically downloaded on first use. This can take up to a couple of minutes depending on your internet connection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "torch",
+    "napari",
     "numpy",
     "qtpy",
     "napari-nifti",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ testing = [
     "napari",
     "pyqt5",
 ]
-
 all = ["napari[all]"]
 
 [project.entry-points."napari.manifest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ testing = [
     "pyqt5",
 ]
 
+all = ["napari[all]"]
+
 [project.entry-points."napari.manifest"]
 napari-nninteractive = "napari_nninteractive:napari.yaml"
 


### PR DESCRIPTION
In this PR I do 3 minor things:
1. add an [all] optional dependency, which is `napari[all]`
2. Use this in the installation instructions (README) to clarify the instructions.
3. Also add `napari` to the regular dependencies. You do import from it, so it's best to have there. It will also let you pin or whatnot if needed.

The net result is if the plugin is installed via the plugin GUI it won't mess with anything the use has (because no specific Qt backend is required), but your easy instructions one-liner will work for someone coming from the README.